### PR TITLE
Fix file field name used in the example curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or using [gunicorn](http://gunicorn.org/):
 
 ##### Request
 
-`curl -F "file=@tests/fixtures/demo.docx" --form "from=docx" --form "to=html" 127.0.0.1:5000/convert/`
+`curl -F "document=@tests/fixtures/demo.docx" --form "from=docx" --form "to=html" 127.0.0.1:5000/convert/`
 
 ##### Response
 


### PR DESCRIPTION
Using the wrong field name you will see this error:

```
 - - [27/Mar/2016 00:37:05] "POST /convert/ HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/chalupas/routes.py", line 19, in convert_document
    document = Document(request.files.get('document'))
  File "/usr/local/lib/python2.7/dist-packages/chalupas/models.py", line 11, in __init__
    self.file_name=file.filename
AttributeError: 'NoneType' object has no attribute 'filename'
```

because the field name is `document`.
